### PR TITLE
fix: include 'priority' in custom fields for case API query so priori…

### DIFF
--- a/src/modules/cases/api/CasesAPI.js
+++ b/src/modules/cases/api/CasesAPI.js
@@ -130,7 +130,7 @@ const getCasesList = async (params) => {
       q,
       ids,
       sort,
-      ['custom', ...fields],
+      ['custom', 'priority', ...fields],
       stringifyCaseFilters(filters),
       options,
     );


### PR DESCRIPTION
…ty color will not change  [WTEL-7149](https://webitel.atlassian.net/browse/WTEL-7149)

[WTEL-7149]: https://webitel.atlassian.net/browse/WTEL-7149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ