### PR TITLE
fix: rename variables for clarity in the-sources.vue [WTEL-7475] 

### DIFF
--- a/src/modules/configuration/modules/lookups/modules/sources/components/the-sources.vue
+++ b/src/modules/configuration/modules/lookups/modules/sources/components/the-sources.vue
@@ -209,11 +209,9 @@ function edit(item) {
 
 const {
   showEmpty,
-  image: emptyImage,
-  headline: emptyHeadline,
-  title: emptyTitle,
-  text: emptyText,
-  primaryActionText: emptyPrimaryActionText,
+  image: imageEmpty,
+  text: textEmpty,
+  primaryActionText: primaryActionTextEmpty,
 } = useTableEmpty({
   dataList,
   error,


### PR DESCRIPTION
https://webitel.atlassian.net/browse/WTEL-7475)

(cherry picked from commit a2e7b8230178e7e23f9f66c64060cc65f71885b5)