### PR TITLE
fix(cases - filters): apply restored preset without resetting filters [WTEL-10062]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@webitel/api-services": "^0.1.54",
 				"@webitel/styleguide": "~26.2.19",
 				"@webitel/ui-datalist": "^1.1.62",
-				"@webitel/ui-sdk": "~26.8.13",
+				"@webitel/ui-sdk": "^26.8.25",
 				"axios": "^1.18.1",
 				"clipboard-copy": "^4.0.1",
 				"date-fns": "^4.1.x",
@@ -3726,9 +3726,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.8.24",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.24.tgz",
-			"integrity": "sha512-Dl6QENWllIH82wR7ldJYa4qL35o/BAF91VLrj1IYqyTGRzMvAn9Eo7hWWHdoPq/BvK034CcQfdZUNbTGVI0LjA==",
+			"version": "26.8.25",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.25.tgz",
+			"integrity": "sha512-Bv30z/n9UOv45GP/dw00bjVoERDgztPV/kgAXQpzcisfIw71dLUTOnjPcYllyKbo67EPnAisojeuAiRCSpdKqQ==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3697,9 +3697,9 @@
 			"integrity": "sha512-YfnxQBeIuLw6G55bq3dz1Q/zLoV+QH5zxoxgCOaQaugK/6oCOQqCDNUbdoX2lp8IZatt71g5607S+jig2sW4/w=="
 		},
 		"node_modules/@webitel/ui-datalist": {
-			"version": "1.1.58",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.58.tgz",
-			"integrity": "sha512-uhW5VgLy0tLs45JQRAUTKYB2A7+1p9gx7hZftKgwv5N0LOvG1yroh5NvDSkqXBRliOa41SE41Bqk+0H0736EUw==",
+			"version": "1.1.61",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.61.tgz",
+			"integrity": "sha512-pAvE76SdWMl+P3hSyl0k2NCrO9BXoeJ8TYA275IPsqZlGcZEtB7MrM9nIr9qVu6wM4ZynANnmtGuuDBrRtlXMQ==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@vueuse/core": "^14.0",
 				"@webitel/api-services": "^0.1.54",
 				"@webitel/styleguide": "~26.2.19",
-				"@webitel/ui-datalist": "^1.1.56",
+				"@webitel/ui-datalist": "^1.1.62",
 				"@webitel/ui-sdk": "~26.8.13",
 				"axios": "^1.18.1",
 				"clipboard-copy": "^4.0.1",
@@ -3697,9 +3697,9 @@
 			"integrity": "sha512-YfnxQBeIuLw6G55bq3dz1Q/zLoV+QH5zxoxgCOaQaugK/6oCOQqCDNUbdoX2lp8IZatt71g5607S+jig2sW4/w=="
 		},
 		"node_modules/@webitel/ui-datalist": {
-			"version": "1.1.61",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.61.tgz",
-			"integrity": "sha512-pAvE76SdWMl+P3hSyl0k2NCrO9BXoeJ8TYA275IPsqZlGcZEtB7MrM9nIr9qVu6wM4ZynANnmtGuuDBrRtlXMQ==",
+			"version": "1.1.62",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.62.tgz",
+			"integrity": "sha512-wLVTOu5nb1Ne5/ZAsc/syHakw6dnhSzS+ZSLUEeanJxgMgI5NT4meIUY81gm1GE0O1S9gOHJjjbWlWk9kggH9A==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@vueuse/core": "^14.0",
 		"@webitel/api-services": "^0.1.54",
 		"@webitel/styleguide": "~26.2.19",
-		"@webitel/ui-datalist": "^1.1.56",
+		"@webitel/ui-datalist": "^1.1.62",
 		"@webitel/ui-sdk": "~26.8.13",
 		"axios": "^1.18.1",
 		"clipboard-copy": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@webitel/api-services": "^0.1.54",
 		"@webitel/styleguide": "~26.2.19",
 		"@webitel/ui-datalist": "^1.1.62",
-		"@webitel/ui-sdk": "~26.8.13",
+		"@webitel/ui-sdk": "^26.8.25",
 		"axios": "^1.18.1",
 		"clipboard-copy": "^4.0.1",
 		"date-fns": "^4.1.x",

--- a/src/modules/cases/components/cases-filters-panel.vue
+++ b/src/modules/cases/components/cases-filters-panel.vue
@@ -11,6 +11,7 @@
     @filter:delete="deleteFilter"
     @filter:reset-all="resetFilters"
     @preset:apply="applyPreset"
+    @preset:restore="restorePreset"
     @hide="emit('hide')"
   />
 </template>
@@ -71,8 +72,15 @@ const resetFilters = () => {
 	});
 };
 
+/**
+ * preset cached in localStorage – filters must survive, so no reset here
+ */
+const restorePreset = (snapshot: string) => {
+	filtersManager.value.fromString(snapshot);
+};
+
 const applyPreset = (snapshot: string) => {
 	resetFilters();
-	filtersManager.value.fromString(snapshot);
+	restorePreset(snapshot);
 };
 </script>

--- a/src/modules/cases/components/cases-filters-panel.vue
+++ b/src/modules/cases/components/cases-filters-panel.vue
@@ -72,15 +72,15 @@ const resetFilters = () => {
 	});
 };
 
+const applyPreset = (snapshot: string) => {
+	resetFilters();
+	filtersManager.value.fromString(snapshot);
+};
+
 /**
  * preset cached in localStorage – filters must survive, so no reset here
  */
 const restorePreset = (snapshot: string) => {
 	filtersManager.value.fromString(snapshot);
-};
-
-const applyPreset = (snapshot: string) => {
-	resetFilters();
-	restorePreset(snapshot);
 };
 </script>


### PR DESCRIPTION
## Description

Depends on webitel/webitel-ui-sdk#1627.

`table-filters-panel` used to emit `preset:apply` both when the user picked a preset and when the preset cached in `localStorage` was restored on mount. `applyPreset` resets filters first, so the cached preset wiped the filters the user arrived with (including ones restored from the route) before applying itself.

The SDK now emits a separate `preset:restore` for the cached case. Handle it with a `restorePreset` that only merges the snapshot:

```ts
const restorePreset = (snapshot: string) => {
  filtersManager.value.fromString(snapshot);
};

const applyPreset = (snapshot: string) => {
  resetFilters();
  restorePreset(snapshot);
};
```

Picking a preset in the popup is unchanged — it still resets everything except `search` first. `resetFilters` itself is untouched.

Note the SDK also gates the restore: it does not fire at all while filters are applied, so this handler only runs on a visit that arrives without them.

## Verification

- `npm run typecheck` → exit 0

Not yet verified in the browser — needs the SDK change published or linked.

## Related Tasks

* [WTEL-10062](https://webitel.atlassian.net/browse/WTEL-10062)

## Related PR's / Issues

* webitel/webitel-ui-sdk#1627
* webitel/cc-history#691

## Todos

- [x] Implementation
- [ ] Bump `@webitel/ui-datalist` once webitel/webitel-ui-sdk#1627 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-10062]: https://webitel.atlassian.net/browse/WTEL-10062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ