### PR TITLE
fix: add crm/ prefix to table filter namespaces [WTEL-10093]

### DIFF
--- a/src/modules/cases/namespace.ts
+++ b/src/modules/cases/namespace.ts
@@ -1,1 +1,1 @@
-export const CasesNamespace = 'cases';
+export const CasesNamespace = 'crm/cases';

--- a/src/modules/configuration/namespace.ts
+++ b/src/modules/configuration/namespace.ts
@@ -1,1 +1,1 @@
-export const ConfigurationNamespace = `configuration`;
+export const ConfigurationNamespace = `crm/configuration`;

--- a/src/modules/contacts/modules/cases/namespace.ts
+++ b/src/modules/contacts/modules/cases/namespace.ts
@@ -1,1 +1,1 @@
-export const ContactCasesNamespace = 'contacts/card/cases';
+export const ContactCasesNamespace = 'crm/contacts/card/cases';

--- a/src/modules/contacts/namespace.ts
+++ b/src/modules/contacts/namespace.ts
@@ -1,1 +1,1 @@
-export const ContactsNamespace = 'contacts';
+export const ContactsNamespace = 'crm/contacts';


### PR DESCRIPTION
## Summary
- Add `crm/` prefix to root namespace constants (`cases`, `contacts`, `configuration`, `contacts/card/cases`)
- Child namespaces inherit the prefix via parent imports (e.g. `crm/cases/comments`, `crm/configuration/lookups/...`)
- Scopes persisted filter/header localStorage keys to the CRM app

[WTEL-10093](https://webitel.atlassian.net/browse/WTEL-10093)

## Test plan
- [ ] Open Cases list — filters and column headers persist correctly under new namespace
- [ ] Open Contacts list — same check
- [ ] Open Contact card → Cases tab — filters work
- [ ] Open Configuration → Lookups (statuses, priorities, SLAs, etc.) — table state persists
- [ ] Verify no stale localStorage keys from old namespaces cause UI glitches (clear storage if needed)


Made with [Cursor](https://cursor.com)

[WTEL-10093]: https://webitel.atlassian.net/browse/WTEL-10093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ