### PR TITLE
refactor: remove @aliasedDeps axios alias [WTEL-10132](https://webitel.atlassian.net/browse/WTEL-10132)

### DIFF
--- a/src/app/api/instance.js
+++ b/src/app/api/instance.js
@@ -1,6 +1,10 @@
-import { getDefaultInstance } from '@webitel/api-services/api/defaults';
+import { getDefaultAxiosInstance } from '@webitel/api-services/api/axios';
 
-export const instance = getDefaultInstance();
+/*
+ * The same instance generated api-services clients use by default, so
+ * interceptors or header changes made here apply to generated calls too.
+ */
+export const instance = getDefaultAxiosInstance();
 
 // compat. prefer named export
 export default instance;

--- a/tests/config/config.js
+++ b/tests/config/config.js
@@ -44,9 +44,6 @@ const axios = axiosMock();
 vi.doMock('@webitel/ui-sdk/src/api/axios/generateInstance.js', () => ({
 	default: () => axios().default,
 }));
-vi.doMock('@aliasedDeps/api-services/axios', () => ({
-	default: () => axios().default,
-}));
 
 beforeAll(async () => {
 	const store = (await import('../../src/app/store/index.js')).default;

--- a/tests/mocks/axios-instance.js
+++ b/tests/mocks/axios-instance.js
@@ -1,6 +1,0 @@
-import axiosMock from '@webitel/ui-sdk/src/tests/mocks/axiosMock';
-
-const mock = axiosMock()().default;
-
-export const instance = mock;
-export default mock;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,10 +37,6 @@ export default ({ mode }) => {
 				vue: '@vue/compat',
 				'lodash/fp': 'lodash-es',
 				lodash: 'lodash-es',
-				'@aliasedDeps/api-services/axios': resolve(
-					__dirname,
-					'src/app/api/instance',
-				),
 				/* vue-datepicker v4 relies on date-fns v2
        where "/esm" dir still exists. need to update vue-datepicker to v8 at least */
 				'date-fns/esm': 'date-fns',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,4 @@
 import vue from '@vitejs/plugin-vue';
-import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -21,10 +20,6 @@ export default defineConfig({
 		testTimeout: 30000,
 		alias: {
 			vue: 'vue',
-			'@aliasedDeps/api-services/axios': resolve(
-				__dirname,
-				'tests/mocks/axios-instance.js',
-			),
 			'lodash/fp': 'lodash-es',
 			lodash: 'lodash-es',
 		},


### PR DESCRIPTION
> **Draft — blocked on releases.** See [Blocked on](#blocked-on) below. CI is expected to be red until `@webitel/api-services` and `@webitel/ui-sdk` ship the upstream change.

## Why

[webitel-ui-sdk#1658](https://github.com/webitel/webitel-ui-sdk/pull/1658) removes the `@aliasedDeps/api-services/axios` import from `@webitel/api-services` generated services. They now import an internal `genClient` module — a lazy proxy over `getDefaultInstance()`, swappable with `setDefaultAxiosInstance()`. Consumers no longer need a build-time alias for the package to resolve.

crm declared that alias in three places and got nothing from it: `src/app/api/instance.js` was a bare `getDefaultInstance()` call — exactly what the package now falls back to on its own.

## Changes

- **`src/app/api/instance.js`** — re-exports `getDefaultAxiosInstance()` instead of building its own. The nine hand-written wrappers that import it (`EmailsAPI`, `TimelineAPI`, `ContactCasesAPI`, …) are untouched, and now share one instance with the generated services. Without this there'd be two identically-configured instances, and a later `instance.interceptors.use(…)` in crm would silently not apply to generated calls.
- **`vite.config.ts`**, **`vitest.config.ts`** — alias entries deleted.
- **`tests/config/config.js`** — the alias-specific `vi.doMock` deleted. No replacement needed: the setup already `vi.doMock`s the `axios` package itself, which intercepts the `axios.create()` inside `generateInstance` whichever path reaches it. So no `setDefaultAxiosInstance` call anywhere — app or tests.
- **`tests/mocks/axios-instance.js`** — deleted, orphaned once the vitest alias is gone (it had no other referrer).

## Blocked on

1. webitel-ui-sdk#1658 merged, `@webitel/api-services` published.
2. **`@webitel/ui-sdk` republished from that commit.** Its rollup config listed the alias specifier under `external`, so the shipped `dist/` still contains `import f from "@aliasedDeps/api-services/axios"`. Building crm against a stale ui-sdk dist fails with `Rolldown failed to resolve import "@aliasedDeps/api-services/axios"`. #1658 removes it from `external`; a rebuild clears it.
3. Bump both libs on this branch via `libs.update.yml`, then mark ready for review.

## Verification

Run locally with `node_modules/@webitel/{api-services,ui-sdk}` symlinked to the workspace checkouts on the #1658 branch (`utils:link-libs`):

- `npm run build` — **green**. Same build against a stale ui-sdk dist fails on the unresolved alias; after `npm run build` in webitel-ui-sdk, the fresh dist has zero alias references and crm builds. The crm bundle contains no `aliasedDeps`.
- `npm run test:unit` — 1 passed, 1 failed (`the-contacts.spec.js`, `getActivePinia() was called but there was no active Pinia`). **Pre-existing** — identical result on unmodified `main`, unrelated to axios.
- `npm run typecheck` — 45 errors, byte-identical count on unmodified `main`; none axios- or instance-related (they're the zod v3/v4 duplicate-install and vue-router signature errors).
- `grep -rn aliasedDeps` across crm → zero hits.

Not verified: runtime behaviour in a browser (`npm run dev`, contact list / timeline requests, 401 redirect). Worth a pass once the libs are bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)